### PR TITLE
Fix not pass domain

### DIFF
--- a/src/flow/append.js
+++ b/src/flow/append.js
@@ -26,7 +26,7 @@ export function valueOf(data, options) {
     const v = typeof value === "function" ? value : () => value;
     const V = data.map(v);
     if (!range) return [key, V];
-    const domain = extent(V);
+    const { domain = extent(V) } = property;
     const transform = scale(domain, range);
     const scaled = V.map(transform);
     return [key, scaled];

--- a/test/apps/particle-cluster-shapes.js
+++ b/test/apps/particle-cluster-shapes.js
@@ -14,6 +14,11 @@ export function particleClusterShapes() {
     y: (d) => d.location.y,
     fill: cm.rgb(0),
     stroke: cm.rgb(0),
+    rotate: {
+      value: (d) => d.location.x,
+      domain: [0, app.prop("width")],
+      range: [0, cm.TWO_PI * 2],
+    },
     fillOpacity: {
       value: (d) => d.lifespan,
       domain: [0, 255],


### PR DESCRIPTION
Makes `prop.domain` valid.

```js
const options = {
  x: (d) => d.location.x,
  y: (d) => d.location.y,
  fill: cm.rgb(0),
  stroke: cm.rgb(0),
  rotate: {
    value: (d) => d.location.x,
    domain: [0, app.prop("width")], // this line
    range: [0, cm.TWO_PI * 2],
  },
  fillOpacity: {
    value: (d) => d.lifespan,
    domain: [0, 255],
    range: [0, 0.6],
  },
  strokeOpacity: {
    value: (d) => d.lifespan,
    domain: [0, 255],
    range: [0, 1],
  },
};

```