### PR TITLE
Remove cols and rows for cm.terminal

### DIFF
--- a/test/apps/terminal-matrix.js
+++ b/test/apps/terminal-matrix.js
@@ -4,8 +4,8 @@ import { dispose } from "../dispose.js";
 export async function terminalMatrix() {
   const app = cm.app({
     mode: "double",
-    cols: 3,
-    rows: 3,
+    width: "3",
+    height: "3",
     renderer: await cm.terminal(),
   });
 

--- a/test/apps/terminal-point.js
+++ b/test/apps/terminal-point.js
@@ -3,17 +3,14 @@ import { dispose } from "../dispose.js";
 
 export async function terminalPoint() {
   const app = cm.app({
-    cols: 10,
-    rows: 3,
-    frameRate: 5,
     renderer: await cm.terminal(),
   });
 
   let x = 0;
 
   app.on("update", () => {
-    const i = x % app.prop("cols");
-    const j = (x / app.prop("cols")) | 0;
+    const i = x % app.prop("width");
+    const j = (x / app.prop("width")) | 0;
     app.append(cm.clear, { fill: "#000" });
     app.append(cm.point, { x: i, y: j, stroke: cm.cfb("@") });
     x += 1;


### PR DESCRIPTION
close: https://github.com/charming-art/charming-app/issues/68

```js
const app = cm.app({
  renderer: await cm.terminal(),
  width: 100, // in pixel
  height: 50, // in pixel
})
```

```js
const app = cm.app({
  renderer: await cm.terminal(),
  width: '100', // in cell number
  height: '50', // in cell number
})
```