### PR TITLE
Fix nested groups

### DIFF
--- a/src/canvas/circle.js
+++ b/src/canvas/circle.js
@@ -4,7 +4,7 @@ function applyMatrix(context, matrices) {
 
 export function canvas_circle(I, value) {
   const context = this._ctx;
-  const {x: X = [], y: Y = [], r: R = [], fill: F = [], M = []} = value;
+  const {x: X = [], y: Y = [], r: R = [], fill: F = [], matrix: M = []} = value;
   for (const i of I) {
     context.save();
     applyMatrix(context, M[i] ?? []);

--- a/src/shapes/background.js
+++ b/src/shapes/background.js
@@ -1,3 +1,3 @@
 export function background({fill}) {
-  return () => ({transform: (renderer) => renderer.background({fill})});
+  return (data) => ({...data, transform: (renderer) => renderer.background({fill})});
 }

--- a/src/shapes/circle.js
+++ b/src/shapes/circle.js
@@ -1,9 +1,10 @@
 import {attribute} from "./attribute.js";
 
 export function circle({x, y, fill, r}) {
-  return ({data} = {data: [0]}) => {
+  return ({data = [0], x: px, y: py, rotate: protate, ...rest} = {}) => {
     const I = Array.from({length: data.length}, (_, i) => i);
     return {
+      ...rest,
       ...(x !== undefined && {x: I.map((i) => attribute(x, i, data))}),
       ...(y !== undefined && {y: I.map((i) => attribute(y, i, data))}),
       ...(r !== undefined && {r: I.map((i) => attribute(r, i, data))}),

--- a/test/apps/circles2.js
+++ b/test/apps/circles2.js
@@ -9,7 +9,10 @@ export function circles2() {
       cm.map((_, i, data) => (i * Math.PI) / data.length),
       cm.group(
         {x: (t) => Math.cos(t) * Math.cos(t * 3) * 250 + 280},
-        cm.group({y: (t) => Math.sin(t) * Math.cos(t * 3) * 250 + 320}, cm.circle({r: 10, x: 0, y: 0})),
+        cm.group(
+          {y: (t) => Math.sin(t) * Math.cos(t * 3) * 250 + 320},
+          cm.group(cm.circle({r: 10, x: 0, y: 0}), cm.circle({r: 3, x: 0, y: 0, fill: "white"})),
+        ),
       ),
     ),
   });


### PR DESCRIPTION

<img width="583" alt="image" src="https://github.com/user-attachments/assets/f3c24a91-c780-436d-a40d-e4dc86ff1de2">

```js
import * as cm from "@charming-art/charming";

export function circles2() {
  return cm.render({
    width: 640,
    height: 640,
    setup: cm.flow(
      cm.range(120),
      cm.map((_, i, data) => (i * Math.PI) / data.length),
      cm.group(
        {x: (t) => Math.cos(t) * Math.cos(t * 3) * 250 + 280},
        cm.group(
          {y: (t) => Math.sin(t) * Math.cos(t * 3) * 250 + 320},
          cm.group(cm.circle({r: 10, x: 0, y: 0}), cm.circle({r: 3, x: 0, y: 0, fill: "white"})),
        ),
      ),
    ),
  });
}
```