### PR TITLE
svg -> SVG, html -> HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 The JavaScript library for generative art based on SVG.
 
 ```js
-import {svg, flow} from "charmingjs";
+import {SVG, flow} from "charmingjs";
 
 const state = flow()
   .state("x", 0)
   .on("loop", () => (state.x = Math.abs(Math.sin(Date.now() / 1000)) * 200))
   .join();
 
-const node = svg.svg({width: 200, height: 50}, [
-  svg.circle({
+const node = SVG.svg({width: 200, height: 50}, [
+  SVG.circle({
     cx: state.select("x"),
     cy: 25,
     r: 20,

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -24,7 +24,7 @@ const moduleName = (name) => {
 // More props: https://genji-md.dev/reference/props
 const props = {
   Theme: DefaultTheme,
-  library: {cm: {...cm, ...extended}, svg: cm.svg, html: cm.html},
+  library: {cm: {...cm, ...extended}, SVG: cm.SVG, html: cm.HTML},
   transform: {
     module(code) {
       let newCode = code

--- a/docs/api-index.md
+++ b/docs/api-index.md
@@ -4,8 +4,8 @@
 
 Creating SVG and HTML with pure function calls.
 
-- [_cm_.**svg**](/charming-dom#svg) - create a SVG element with the specified attributes and child nodes.
-- [_cm_.**html**](/charming-dom#html) - create a HTML element with the specified attributes and child nodes.
+- [_cm_.**SVG**](/charming-dom#SVG) - create SVG elements with the specified attributes and child nodes.
+- [_cm_.**HTML**](/charming-dom#HTML) - create HTML elements with the specified attributes and child nodes.
 
 ## [Charming Flow](/charming-flow)
 

--- a/docs/charming-dom.md
+++ b/docs/charming-dom.md
@@ -2,34 +2,34 @@
 
 Create SVG and HTML elements using pure function calls.
 
-## _cm_.**svg.[tagName](_[attributes,] children_)** {#svg}
+## _cm_.**SVG.[tagName](_[attributes,] children_)** {#svg}
 
 Creates an SVG element with the specified attributes and child nodes. The _svg_ object is used to create all SVG elements:
 
 ```js eval inspector=false
-svg = cm.svg;
+SVG = cm.SVG;
 ```
 
 Use _svg.tagName_ to create an element:
 
 ```js
-svg.svg(); // Create a svg element.
-svg.circle(); // Create a circle element.
-svg.rect(); // Create a rect element.
+SVG.svg(); // Create a svg element.
+SVG.circle(); // Create a circle element.
+SVG.rect(); // Create a rect element.
 ```
 
 Specify attributes as an object:
 
 ```js eval
-svg.svg({width: 100, height: 100, style: "background:black"});
+SVG.svg({width: 100, height: 100, style: "background:black"});
 ```
 
 Pass an array of elements as children:
 
 ```js eval
-svg.svg({width: 100, height: 100, style: "background:black"}, [
+SVG.svg({width: 100, height: 100, style: "background:black"}, [
   // Add a circle SVG element as child
-  svg.circle({cx: 50, cy: 50, r: 40, fill: "white"}),
+  SVG.circle({cx: 50, cy: 50, r: 40, fill: "white"}),
 ]);
 ```
 
@@ -37,15 +37,15 @@ Without attributes, specify child elements as an array:
 
 ```js eval
 // Without specify attributes
-svg.svg([svg.circle({cx: "50%", cy: "50%", r: 40, fill: "black"})]);
+SVG.svg([SVG.circle({cx: "50%", cy: "50%", r: 40, fill: "black"})]);
 ```
 
 Here's how to render a list of elements:
 
 ```js eval
-svg.svg(
+SVG.svg(
   [50, 100, 150, 200, 250].map((cx) =>
-    svg.circle({
+    SVG.circle({
       cx,
       cy: "50%",
       r: 20,
@@ -55,6 +55,6 @@ svg.svg(
 );
 ```
 
-## _cm_.**html.[tagName](_[attributes,] children_)** {#html}
+## _cm_.**HTML.[tagName](_[attributes,] children_)** {#HTML}
 
-Similar to cm.svg, but creates HTML elements instead of SVG elements.
+Similar to cm.SVG, but creates HTML elements instead of SVG elements.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,7 +48,7 @@ In vanilla HTML, Charming can be imported as an ES module, say from jsDelivr:
 <script type="module">
   import * as cm from "https://cdn.jsdelivr.net/npm/charmingjs/+esm";
 
-  const node = cm.svg.svg();
+  const node = cm.SVG.svg();
 
   document.body.append(node);
 </script>
@@ -61,7 +61,7 @@ Charming is also available as a UMD bundle for legacy browsers.
 ```html
 <script src="https://cdn.jsdelivr.net/npm/charmingjs"></script>
 <script>
-  const svg = cm.svg.svg();
+  const svg = cm.SVG.svg();
 
   document.body.append(node);
 </script>

--- a/docs/what-is-charming.md
+++ b/docs/what-is-charming.md
@@ -5,15 +5,15 @@
 Charming lets you create dynamic and expressive generative art and visualizations effortlessly. Here's a quick example that give you a sense of Charming:
 
 ```js eval t=module
-import {svg, flow} from "charmingjs";
+import {SVG, flow} from "charmingjs";
 
 const state = flow()
   .state("x", 0)
   .on("loop", () => (state.x = Math.abs(Math.sin(Date.now() / 1000) * 200)))
   .join();
 
-const node = svg.svg({width: 200, height: 50}, [
-  svg.circle({
+const node = SVG.svg({width: 200, height: 50}, [
+  SVG.circle({
     cx: state.select("x"),
     cy: 25,
     r: 20,
@@ -28,11 +28,11 @@ document.body.append(node);
 Charming provides a declarative way to create SVG through pure function calls. It exports an _svg_ proxy object to **create SVG elements directly**. For example, to create a white circle on a black background:
 
 ```js eval t=module
-import {svg} from "charmingjs";
+import {SVG} from "charmingjs";
 
-const node = svg.svg({width: 100, height: 100}, [
-  svg.rect({x: 0, y: 0, width: 100, height: 100, fill: "black"}),
-  svg.circle({cx: 50, cy: 50, r: 40, fill: "white"}),
+const node = SVG.svg({width: 100, height: 100}, [
+  SVG.rect({x: 0, y: 0, width: 100, height: 100, fill: "black"}),
+  SVG.circle({cx: 50, cy: 50, r: 40, fill: "white"}),
 ]);
 
 document.body.append(node);
@@ -49,10 +49,10 @@ play = Inputs.button("Replay");
 ```
 
 ```js eval t=module,replayable
-import {svg, transition} from "charmingjs";
+import {SVG, transition} from "charmingjs";
 
-const node = svg.svg({width: 100, height: 100}, [
-  svg.rect({x: 0, y: 0, width: 100, height: 100, fill: "black"}),
+const node = SVG.svg({width: 100, height: 100}, [
+  SVG.rect({x: 0, y: 0, width: 100, height: 100, fill: "black"}),
   transition(
     {
       keyframes: [
@@ -60,7 +60,7 @@ const node = svg.svg({width: 100, height: 100}, [
         {attr: {fill: "#EE7A64", r: 40}, duration: 2000},
       ],
     },
-    [svg.circle({cx: 50, cy: 50, r: 40, fill: "#4B68C9"})],
+    [SVG.circle({cx: 50, cy: 50, r: 40, fill: "#4B68C9"})],
   ),
 ]);
 
@@ -72,7 +72,7 @@ document.body.append(node);
 For dynamic features like interactions and animations, Charming uses a reactive state management concept called _Flow_. In a flow, you can define _states_, _computed states_, and _effects_, then bind them to SVG elements. When states change, the elements update automatically—no need to manually sync states and views. For instance, you can easily create a random walker that changes color on mouse hover:
 
 ```js eval t=module
-import {flow, random, constrain} from "charmingjs";
+import {SVG, flow, random, constrain} from "charmingjs";
 
 const width = 600;
 const height = 150;
@@ -90,8 +90,8 @@ const state = flow()
   })
   .join();
 
-const node = svg.svg({width, height}, [
-  svg.circle({
+const node = SVG.svg({width, height}, [
+  SVG.circle({
     cx: state.select("clampedX"),
     cy: state.select("clampedY"),
     fill: state.select("color"),
@@ -109,7 +109,7 @@ document.body.append(node);
 Components in Charming are reusable UI and logic elements. Using the _component_ function, you can define a function that accepts _props_ and _flow_ parameters to return SVG elements. For example, to define a random _walker component_:
 
 ```js eval t=moduleWalker
-import {component, random, constrain} from "charmingjs";
+import {SVG, component, random, constrain} from "charmingjs";
 
 const walker = component((props, flow) => {
   const {width, height} = props;
@@ -127,7 +127,7 @@ const walker = component((props, flow) => {
     })
     .join();
 
-  return svg.circle({
+  return SVG.circle({
     cx: state.select("clampedX"),
     cy: state.select("clampedY"),
     fill: state.select("color"),
@@ -141,12 +141,12 @@ const walker = component((props, flow) => {
 You can then use this _walker component_ like any other SVG element:
 
 ```js eval t=module
-import {svg} from "charmingjs";
+import {SVG} from "charmingjs";
 
 const width = 600;
 const height = 150;
 
-const node = svg.svg({width, height}, [
+const node = SVG.svg({width, height}, [
   walker({width, height}),
   walker({width, height}),
   walker({width, height}),
@@ -163,7 +163,7 @@ Note that the concept of a component is very similar to a class—both enable re
 What if we want to draw a random walker with a rectangle element? When using classes, we would typically use inheritance to override the display function. However, in Charming, you can define a _useWalker composition_ like this:
 
 ```js eval t=moduleUseWalker
-import {svg, random, constrain} from "charmingjs";
+import {SVG, random, constrain} from "charmingjs";
 
 const useWalker = (flow, width, height) =>
   flow()
@@ -183,12 +183,12 @@ const useWalker = (flow, width, height) =>
 You can then use this _useWalker composition_ in your square walker component:
 
 ```js eval t=moduleSquareWalker
-import {svg, component} from "charmingjs";
+import {SVG, component} from "charmingjs";
 
 const squareWalker = component((props, flow) => {
   const state = useWalker(flow, props.width, props.height);
 
-  return svg.rect({
+  return SVG.rect({
     x: state.select((state) => state.clampedX - 20),
     y: state.select((state) => state.clampedY - 20),
     fill: state.select("color"),
@@ -203,12 +203,12 @@ const squareWalker = component((props, flow) => {
 And draw two walkers like this:
 
 ```js eval t=module
-import {svg, range} from "charmingjs";
+import {SVG, range} from "charmingjs";
 
 const width = 600;
 const height = 150;
 
-const node = svg.svg({width, height}, [
+const node = SVG.svg({width, height}, [
   walker({width, height}),
   squareWalker({width, height}), // Use SquareWalker
 ]);
@@ -223,7 +223,7 @@ const squareWalker = component((props, flow) => {
   const walker = useWalker(flow, props.width, props.height);
   const hover = useHover(flow);
 
-  return svg.rect({
+  return SVG.rect({
     x: walker.select((state) => state.clampedX - 20),
     y: walker.select((state) => state.clampedY - 20),
     fill: walker.select("color"),

--- a/src/dom.js
+++ b/src/dom.js
@@ -12,6 +12,6 @@ function exclude(proxy) {
   });
 }
 
-export const svg = exclude(_html("http://www.w3.org/2000/svg"));
+export const SVG = exclude(_html("http://www.w3.org/2000/svg"));
 
-export const html = exclude(_html);
+export const HTML = exclude(_html);

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 export {component} from "echox";
 export * from "charmingjs-vector";
-export {svg, html} from "./dom.js";
+export {SVG, HTML} from "./dom.js";
 export {flow} from "./flow.js";
 export {transition} from "./transition.js";

--- a/test/dom.spec.js
+++ b/test/dom.spec.js
@@ -1,24 +1,24 @@
-import {svg, html} from "../src/index.js";
+import {SVG, HTML} from "../src/index.js";
 import {test, expect} from "vitest";
 
 test("svg should create SVG elements", () => {
-  const el = svg.rect();
+  const el = SVG.rect();
   expect(el.tagName).toBe("rect");
 });
 
 test("svg should ignore then, next, and return", () => {
-  expect(svg.then).toBe(undefined);
-  expect(svg.next).toBe(undefined);
-  expect(svg.return).toBe(undefined);
+  expect(SVG.then).toBe(undefined);
+  expect(SVG.next).toBe(undefined);
+  expect(SVG.return).toBe(undefined);
 });
 
 test("html should create HTML elements", () => {
-  const el = html.div();
+  const el = HTML.div();
   expect(el.tagName).toBe("DIV");
 });
 
 test("html should ignore then, next, and return", () => {
-  expect(html.then).toBe(undefined);
-  expect(html.next).toBe(undefined);
-  expect(html.return).toBe(undefined);
+  expect(HTML.then).toBe(undefined);
+  expect(HTML.next).toBe(undefined);
+  expect(HTML.return).toBe(undefined);
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -3,8 +3,8 @@ import * as cmVector from "charmingjs-vector";
 import {test, expect} from "vitest";
 
 test("cm should have expected exports", () => {
-  expect(cm.html).toBeDefined();
-  expect(cm.svg).toBeDefined();
+  expect(cm.HTML).toBeDefined();
+  expect(cm.SVG).toBeDefined();
   expect(cm.flow).toBeDefined();
   expect(cm.component).toBeDefined();
 


### PR DESCRIPTION
> close: https://github.com/charming-art/charming/issues/285

Rename **cm**._svg_ to **cm**._SVG_, because _svg.svg_ is confusing:

```js
// Before
import {svg} from "charmingjs";

const node = svg.svg({width: 100, height: 100}, [
  svg.rect({x: 0, y: 0, width: 100, height: 100, fill: "black"}),
  svg.circle({cx: 50, cy: 50, r: 40, fill: "white"}),
]);
```
```js
// After
import {SVG} from "charmingjs";

const node = SVG.svg({width: 100, height: 100}, [
  SVG.rect({x: 0, y: 0, width: 100, height: 100, fill: "black"}),
  SVG.circle({cx: 50, cy: 50, r: 40, fill: "white"}),
]);
```

Thanks @jackbdu for discussions and suggestions!